### PR TITLE
fix(headings): Fixed styling of headings

### DIFF
--- a/src/style/_base.scss
+++ b/src/style/_base.scss
@@ -6,11 +6,13 @@ body {
 }
 
 h1 {
-    font-size: rem(40px);
+    font-size: $space-xl;
+}
+
+h2 {
+    font-size: $space-l;
 }
 
 h1, h2 {
-    margin-left: 0;
-    margin-top: rem(50px);
-    font-weight: normal;
+    margin-bottom: $space-m;
 }

--- a/src/style/_page.scss
+++ b/src/style/_page.scss
@@ -2,6 +2,7 @@
     margin-bottom: rem(80px);
     h1 {
         color: $abbey;
+        margin: $space-xxl 0 $space-l;
     }
     nav ul {
         border-left: 2px solid $earl-gray;


### PR DESCRIPTION
The styling of the headings changed a bit because we right now only use h2 and h4 to keep possibilities for simpler heading changes. This PR fixes the style of the headings inside the styleguide page because we're using here h1 and h2 tags which are generated from markdown files.